### PR TITLE
feat: addCustomRequestConfiguration in requests

### DIFF
--- a/src/CmisClient.ts
+++ b/src/CmisClient.ts
@@ -231,6 +231,12 @@ export class CmisClient {
       request = request.addCustomHeaders(config.customHeaders);
     }
 
+    if (config?.customRequestConfiguration) {
+      request = request.addCustomRequestConfiguration(
+        config?.customRequestConfiguration,
+      );
+    }
+
     request = request.middleware(middlewares.jsonToFormData);
 
     return config?.raw
@@ -279,6 +285,12 @@ export class CmisClient {
 
     if (config?.customHeaders) {
       request = request.addCustomHeaders(config.customHeaders);
+    }
+
+    if (config?.customRequestConfiguration) {
+      request = request.addCustomRequestConfiguration(
+        config?.customRequestConfiguration,
+      );
     }
     request.middleware(middlewares.jsonToFormData);
 
@@ -382,6 +394,12 @@ export class CmisClient {
       request = request.addCustomHeaders(config.customHeaders);
     }
 
+    if (config?.customRequestConfiguration) {
+      request = request.addCustomRequestConfiguration(
+        config?.customRequestConfiguration,
+      );
+    }
+
     return config?.raw
       ? request.executeRaw(this.destination)
       : request.execute(this.destination);
@@ -429,6 +447,12 @@ export class CmisClient {
 
     if (config?.customHeaders) {
       request = request.addCustomHeaders(config.customHeaders);
+    }
+
+    if (config?.customRequestConfiguration) {
+      request = request.addCustomRequestConfiguration(
+        config?.customRequestConfiguration,
+      );
     }
 
     request = request.middleware(middlewares.jsonToFormData);
@@ -568,6 +592,12 @@ export class CmisClient {
       request = request.addCustomHeaders(config.customHeaders);
     }
 
+    if (config?.customRequestConfiguration) {
+      request = request.addCustomRequestConfiguration(
+        config?.customRequestConfiguration,
+      );
+    }
+
     request.middleware(middlewares.jsonToFormData);
 
     return config?.raw
@@ -695,6 +725,12 @@ export class CmisClient {
       request = request.addCustomHeaders(config.customHeaders);
     }
 
+    if (config?.customRequestConfiguration) {
+      request = request.addCustomRequestConfiguration(
+        config?.customRequestConfiguration,
+      );
+    }
+
     request = request.middleware(middlewares.jsonToFormData);
 
     return config?.raw
@@ -727,6 +763,12 @@ export class CmisClient {
 
     if (config?.customHeaders) {
       request = request.addCustomHeaders(config.customHeaders);
+    }
+
+    if (config?.customRequestConfiguration) {
+      request = request.addCustomRequestConfiguration(
+        config?.customRequestConfiguration,
+      );
     }
 
     return config?.raw
@@ -859,8 +901,10 @@ export class CmisClient {
     objectId: string,
     options: {
       filename?: string;
-      download: 'attachment' | 'inline';
-    } & BaseOptions = { download: 'attachment' },
+      download?: 'attachment' | 'inline';
+    } & BaseOptions = {
+      download: 'attachment',
+    },
   ): Promise<any> {
     const { config, ...optionalParameters } = options;
 
@@ -880,6 +924,12 @@ export class CmisClient {
 
     if (config?.customHeaders) {
       request = request.addCustomHeaders(config.customHeaders);
+    }
+
+    if (config?.customRequestConfiguration) {
+      request = request.addCustomRequestConfiguration(
+        config?.customRequestConfiguration,
+      );
     }
 
     return config?.raw
@@ -968,6 +1018,12 @@ export class CmisClient {
       request = request.addCustomHeaders(config.customHeaders);
     }
 
+    if (config?.customRequestConfiguration) {
+      request = request.addCustomRequestConfiguration(
+        config?.customRequestConfiguration,
+      );
+    }
+
     return config?.raw
       ? request.executeRaw(this.destination)
       : request.execute(this.destination);
@@ -1011,6 +1067,12 @@ export class CmisClient {
 
     if (config?.customHeaders) {
       request = request.addCustomHeaders(config.customHeaders);
+    }
+
+    if (config?.customRequestConfiguration) {
+      request = request.addCustomRequestConfiguration(
+        config?.customRequestConfiguration,
+      );
     }
 
     return config?.raw
@@ -1190,6 +1252,12 @@ export class CmisClient {
 
     if (config?.customHeaders) {
       request = request.addCustomHeaders(config.customHeaders);
+    }
+
+    if (config?.customRequestConfiguration) {
+      request = request.addCustomRequestConfiguration(
+        config?.customRequestConfiguration,
+      );
     }
 
     return config?.raw
@@ -1490,6 +1558,12 @@ export class CmisClient {
       request = request.addCustomHeaders(config.customHeaders);
     }
 
+    if (config?.customRequestConfiguration) {
+      request = request.addCustomRequestConfiguration(
+        config?.customRequestConfiguration,
+      );
+    }
+
     return config?.raw
       ? request.executeRaw(this.destination)
       : request.execute(this.destination);
@@ -1612,6 +1686,12 @@ export class CmisClient {
       request = request.addCustomHeaders(config.customHeaders);
     }
 
+    if (config?.customRequestConfiguration) {
+      request = request.addCustomRequestConfiguration(
+        config?.customRequestConfiguration,
+      );
+    }
+
     request = request.middleware(middlewares.jsonToFormData);
 
     return config?.raw
@@ -1721,6 +1801,12 @@ export class CmisClient {
       request = request.addCustomHeaders(config.customHeaders);
     }
 
+    if (config?.customRequestConfiguration) {
+      request = request.addCustomRequestConfiguration(
+        config?.customRequestConfiguration,
+      );
+    }
+
     request = request.middleware(middlewares.jsonToFormData);
 
     return config?.raw
@@ -1763,6 +1849,12 @@ export class CmisClient {
 
     if (config?.customHeaders) {
       request = request.addCustomHeaders(config.customHeaders);
+    }
+
+    if (config?.customRequestConfiguration) {
+      request = request.addCustomRequestConfiguration(
+        config?.customRequestConfiguration,
+      );
     }
 
     request = request.middleware(middlewares.jsonToFormData);
@@ -1810,6 +1902,12 @@ export class CmisClient {
 
     if (config?.customHeaders) {
       request = request.addCustomHeaders(config.customHeaders);
+    }
+
+    if (config?.customRequestConfiguration) {
+      request = request.addCustomRequestConfiguration(
+        config?.customRequestConfiguration,
+      );
     }
 
     return config?.raw

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,6 +39,12 @@ export type BaseOptions = {
      * Useful for passing additional metadata
      */
     customHeaders?: Record<string, string>;
+
+    /**
+     * Custom Request configurations
+     * @see {@link https://sap.github.io/cloud-sdk/docs/js/features/openapi/execute-request#setting-a-custom-request-configuration}
+     */
+    customRequestConfiguration?: Record<string, string>;
   };
 };
 

--- a/test/CmisClient.spec.ts
+++ b/test/CmisClient.spec.ts
@@ -255,6 +255,28 @@ describe('CmisClient integration with BTP - DMS Service', function () {
       expect(result).toBe(fileContent);
     });
 
+    it('should download a file as arraybuffer', async () => {
+      const filename = `test-downloadFile-${Date.now().toString()}.txt`;
+      const fileContent = 'Lorem ipsum dolor';
+      const inputBuffer = Buffer.from('Lorem ipsum dolor', 'utf-8');
+      document = await cmisClient.createDocument(filename, inputBuffer);
+
+      const outputBuffer = await cmisClient.downloadFile(
+        document.succinctProperties['cmis:objectId'],
+        {
+          download: 'attachment',
+          filename,
+          config: {
+            customRequestConfiguration: {
+              responseType: 'arraybuffer',
+            },
+          },
+        },
+      );
+      expect(Buffer.isBuffer(outputBuffer)).toBe(true);
+      expect(inputBuffer).toEqual(outputBuffer);
+    });
+
     it('should get deleted children', async () => {
       await cmisClient.getDeletedChildren();
     });


### PR DESCRIPTION
In this PR:

* Added the parameter `customRequestConfiguration` in BaseOptions.config
* Change all CmisClient API methods to consider this new prameter, following the same standards as `customHeaders`
* Added one test `should download a file as arraybuffer`, where I basically compare 1-) if the result is a Buffer and 2-) if the `inputBuffer` is equals to the `outputBuffer`.


Example of usage:
```javascript
const resultInArrayBuffer = await cmisClient.downloadFile(
        objectId,
        {
          download: 'attachment',
          filename,
          config: {
            customRequestConfiguration: {
              responseType: 'arraybuffer',
            },
          },
        },
      )
```

More details on the benefits of this feature can be found [here](https://sap.github.io/cloud-sdk/docs/js/features/openapi/execute-request#setting-a-custom-request-configuration) and [here](https://github.com/axios/axios#request-config).

