### PR TITLE
feat(getDocumentUriPath): relative URI path generation for documents

### DIFF
--- a/src/CmisClient.ts
+++ b/src/CmisClient.ts
@@ -2099,6 +2099,45 @@ export class CmisClient {
   }
 
   /**
+   * Retrieves the content and thumbnail URIs for a given CMIS document.
+   *
+   * @async
+   * @param {CmisGeneratedApi.CreateDocumentResponse | string} document - The CMIS document object or its ID as a string.
+   * If a string is provided, it fetches the document using the `getObject` method.
+   * @returns {Promise<{ content?: string; thumbnail?: string }>} An object containing URLs for content and thumbnail.
+   * If the respective stream ID is not available, the URL property will not be set.
+   *
+   * @example
+   * const { content, thumbnail } = await getObjectPath("documentId12345");
+   * console.log(content);  // Outputs content URL
+   * console.log(thumbnail);  // Outputs thumbnail URL
+   */
+  async getDocumentUriPath(
+    document: CmisGeneratedApi.CreateDocumentResponse | string,
+  ): Promise<{ content?: string; thumbnail?: string }> {
+    const object =
+      typeof document == 'string' ? await this.getObject(document) : document;
+
+    const {
+      'cmis:objectId': objectId,
+      'cmis:thumbnailContentStreamId': thumbnailStreamId,
+      'cmis:contentStreamId': contentStreamId,
+    } = object.succinctProperties;
+
+    const path = `/browser/${this.defaultRepository.repositoryId}/root`;
+
+    const buildURL = (streamId: string) =>
+      streamId
+        ? `${path}?cmisselector=content&objectId=${objectId}&streamId=${streamId}`
+        : null;
+
+    return {
+      content: buildURL(contentStreamId),
+      thumbnail: buildURL(thumbnailStreamId),
+    };
+  }
+
+  /**
    * Retrieves the default repository.
    *
    * @returns - The default CMIS repository.

--- a/test/CmisClient.spec.ts
+++ b/test/CmisClient.spec.ts
@@ -480,5 +480,26 @@ describe('CmisClient integration with BTP - DMS Service', function () {
     it('should get children of the given type', async () => {
       await cmisClient.getTypeChildren('cmis:document');
     });
+
+    it('should get the content URL', async () => {
+      const sampleDocument = {
+        succinctProperties: {
+          'cmis:objectId': 'sampleId',
+          'cmis:thumbnailContentStreamId': 'sampleThumbnailStreamId',
+          'cmis:contentStreamId': 'sampleContentStreamId',
+        },
+      };
+
+      const url = await cmisClient.getDocumentUriPath(sampleDocument);
+
+      const expectedBasePath = `/browser/${
+        cmisClient.getDefaultRepository().repositoryId
+      }/root`;
+      const expectedContentUrl = `${expectedBasePath}?cmisselector=content&objectId=sampleId&streamId=sampleContentStreamId`;
+      const expectedThumbnailUrl = `${expectedBasePath}?cmisselector=content&objectId=sampleId&streamId=sampleThumbnailStreamId`;
+
+      expect(url.content).toBe(expectedContentUrl);
+      expect(url.thumbnail).toBe(expectedThumbnailUrl);
+    });
   });
 });


### PR DESCRIPTION
- Generate the relative URI path for a given document.
- Useful for direct access from the front-end.