### PR TITLE
fix(getDocumentUriPath): Typo

### DIFF
--- a/src/CmisClient.ts
+++ b/src/CmisClient.ts
@@ -2120,7 +2120,7 @@ export class CmisClient {
 
     const {
       'cmis:objectId': objectId,
-      'cmis:thumbnailContentStreamId': thumbnailStreamId,
+      'sap:thumbnailContentStreamId': thumbnailStreamId,
       'cmis:contentStreamId': contentStreamId,
     } = object.succinctProperties;
 


### PR DESCRIPTION
There was a typo in `getDocumentUriPath`. It was incorrectly retrieving `thumbnailContentStreamId` from `cmis:` instead of from `sap:`.